### PR TITLE
Moved Password to ini file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ public/index_BACKUP_636.php
 public/index_BASE_636.php
 public/index_LOCAL_636.php
 public/index_REMOTE_636.php
+core/database/db_config.ini

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -10,9 +10,7 @@ require('core/router/Router.php');
 
 include_once('core/util/helpers.php');
 
-$db = new Database('10.11.12.21', '5432',
-    'postgres', '[actual password]', // replace with actual password
-    'New_DB');
+$db = Database::loadFromConfig("../core/database/db_config.ini");
 $db->connect();
 
 $viewLoader = new ViewLoader(BASEPATH.'/views/');

--- a/core/database/Database.php
+++ b/core/database/Database.php
@@ -27,6 +27,14 @@ class Database {
         $this->name = $dbname;
     }
 
+    public static function loadFromConfig($path) {
+        $db_ini = parse_ini_file($path, true);
+        $conn_settings = $db_ini['connection_settings'];
+        return new self($conn_settings['host'], $conn_settings['port'],
+            $conn_settings['user'], $conn_settings['pass'],
+            $conn_settings['dbname']);
+    }
+
     /**
      * Connects to the database based on constructor values.
      */


### PR DESCRIPTION
- Only need to create the `db_config.ini` file for DB connection
- Prevents password from being seen on GitHub
- This file is never added to GitHub and will only be configured once (not every pull)
- Requires a `db_config.ini` file to be added in the `core/database/` folder:

```ini
; This configuration file is used to configure the settings
; for the database connection

[connection_settings]
host = 10.11.12.21
port = 5432
user = postgres
pass = <Actual Password>
dbname = New_DB
```

Fixes #41