### PR TITLE
Changed main-content div overflow-x from 'hidden' to 'auto' in custom.css

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -342,7 +342,7 @@ footer {
     width: 100%;
     padding: 15px;
     overflow-y: auto;
-    overflow-x: hidden;
+    overflow-x: auto;
 }
 
 .tutorial {


### PR DESCRIPTION
Now we won't lose any content if the screen width is set too small.

Fixes #144.