### PR TITLE
Added unsaved changes warning to form pages

### DIFF
--- a/views/forms/form_duplicate_check.php
+++ b/views/forms/form_duplicate_check.php
@@ -29,7 +29,7 @@
 	<input type="hidden" value="" id ="state"  name="state">
 	<input type="hidden" value="" id ="city"  name="city">
 	<input type="hidden" value="" id ="apt"  name="apt">
-	<input id="btnRegister" type="submit" name="namecheck" class="cpca btn" style="margin-bottom: 20px;">
+	<input id="btnRegister" type="submit" name="namecheck" class="cpca btn" onclick="formChanged = false;" style="margin-bottom: 20px;">
 </form>
 
 <div class="modal fade modal-larger" id="matchModal" tabindex="-1" role="dialog" aria-labelledby="matchModal"

--- a/views/forms/intake_packet.php
+++ b/views/forms/intake_packet.php
@@ -1277,6 +1277,18 @@ include('header.php');
 
         </div>  <!-- /#container -->
     </div>  <!-- /#container-fluid class -->
+<script>
+	formChanged = false;
+	$("select,input,textarea").change(function () {formChanged = true;});
+	
+	<!--Adds the "Are you sure you want to leave?" pop-up to page-->
+	window.onbeforeunload = function() {
+		if (formChanged)
+			return true;
+		else
+			return null;
+	};
+</script>
 <style>
 @media print{
   .collapse {

--- a/views/forms/referral_form.php
+++ b/views/forms/referral_form.php
@@ -1008,6 +1008,18 @@ include('header.php');
 
         </div>  <!-- /#container -->
     </div>  <!-- /#container-fluid class -->
+<script>
+	formChanged = false;
+	$("select,input,textarea").change(function () {formChanged = true;});
+	
+	<!--Adds the "Are you sure you want to leave?" pop-up to page-->
+	window.onbeforeunload = function() {
+		if (formChanged)
+			return true;
+		else
+			return null;
+	};
+</script>
 <style>
 @media print{
   .collapse {

--- a/views/forms/self_referral_form.php
+++ b/views/forms/self_referral_form.php
@@ -604,6 +604,18 @@ include('header.php');
         <br><br>
         </div>  <!-- /#container -->
     </div>  <!-- /#container-fluid class -->
+<script>
+	formChanged = false;
+	$("select,input,textarea").change(function () {formChanged = true;});
+	
+	<!--Adds the "Are you sure you want to leave?" pop-up to page-->
+	window.onbeforeunload = function() {
+		if (formChanged)
+			return true;
+		else
+			return null;
+	};
+</script>
 <style>
 @media print{
   .collapse {


### PR DESCRIPTION
The web browser will display a warning pop-up when trying to leave or reload any form pages, and gives the option to stay and not lose your work.

Warning code is removed when the submit button is pressed, allowing the user to submit without getting the pop-up.

Fixes #209 