### PR TITLE
Clearing Cache/ Cookies on Logout

### DIFF
--- a/core/util/helpers.php
+++ b/core/util/helpers.php
@@ -235,7 +235,12 @@ function phoneStrToNum($phoneNum) {
 }
 /**
  * Checks to see if there are any duplicate PID's in the db, then returns a pid if already existing
-*/
+ * @param $db database object
+ * @param $pers_firstname first name of participant in form input field
+ * @param $pers_lastname last name of participant in form input field
+ * @param $pers_middlein initial of middle name of participant in form input field
+ * @reutnr participant id of new/duplicate participant 
+**/
 function checkForDuplicates($db, $pers_firstname,$pers_lastname,$pers_middlein){
     if($_POST['selectedID'] != ""){
         return $pIDResult = $_POST['selectedID'];
@@ -248,3 +253,41 @@ function checkForDuplicates($db, $pers_firstname,$pers_lastname,$pers_middlein){
         return $pIDResult = pg_fetch_result($pIDResult, 0);
     }  
 }
+
+/**
+ * Every time sessionTimeout is called, the start time stored in login will
+ * be checked against the current system time and converted into minutes.
+ * Should the elapsed time between the start time and current system
+ * time exceed 60 minutes, the browser will force a logout.
+**/
+function sessionTimeout(){
+    if(isset($_SESSION['SESSION_START'])){
+        // Create a new check time every time the user goes to a new page
+        $_SESSION['CHECK_TIME'] = time();
+        
+        // Set timeout time in minutes
+        $timeoutTime = 60;
+        
+        // Find total elapsed time and convert to minutes
+        $elapsedTime = ($_SESSION['CHECK_TIME'] - $_SESSION['SESSION_START']) / 60 % 60;
+        
+        // After the elapsed time reaches a limit, force destory the session and set the timeout flag to true
+        if($elapsedTime >= $timeoutTime){
+            session_destroy();
+            session_start();
+            
+            // Extra check for avoiding overwriting sessions
+            if (session_status() === PHP_SESSION_NONE){
+                $_SESSION['timeout'] = true;
+            }else{
+                $_SESSION['timeout'] = true;
+            } 
+            // Redirect user to the login page
+            header("Location: " . BASEURL . "/login");       
+        }
+    }
+         
+}
+
+
+

--- a/page_permissions.ini
+++ b/page_permissions.ini
@@ -9,6 +9,7 @@
 /login = ALLOW *
 /create-account = ALLOW *
 /logout = ALLOW New
+/logout/* = ALLOW New
 /dashboard = ALLOW New
 /help = ALLOW New
 /account-settings/** = ALLOW *

--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -698,6 +698,7 @@ label[for=password] {
 .custom-control-input:checked~.custom-control-indicator:focus {
     outline: none;
 }
+
 /*When printing, display all of the main-content div, and nothing else.*/
 @media print{
     #main-content {

--- a/public/header.php
+++ b/public/header.php
@@ -12,6 +12,10 @@
     <title><?= 'PEP - '. $route['title'] ?></title>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no">
+    
+    <!-- Prevent user browswer from caching -->
+     <meta http-equiv="expires" content="Mon, 26 Jul 1997 05:00:00 GMT"/>
+     <meta http-equiv="pragma" content="no-cache" />
 
     <!-- Stylesheets -->
     <link rel="stylesheet" href="/css/bootstrap.min.css" />

--- a/public/index.php
+++ b/public/index.php
@@ -16,13 +16,17 @@
  * @since 0.1
  */
 
-session_start();
+
 
 require('../bootstrap.php');
 require('../routes.php');
 
 global $router, $view, $db;
 
+// Only create a session if there is not already one there
+if (session_status() === PHP_SESSION_NONE){
+    session_start();
+}
 # checks if url is the current one
 function active($url) {
     global $route;

--- a/public/menu.php
+++ b/public/menu.php
@@ -29,6 +29,7 @@ $active = [
     "reports" => isActive(['/monthly-reports','/quarterly-reports','/year-end-reports','/custom-reports'])
 ];
 
+sessionTimeout(); 
 ?>
 <div class="side-menu">
     <nav class="nav flex-column flex-nowrap">

--- a/views/dashboard.php
+++ b/views/dashboard.php
@@ -1,6 +1,5 @@
 <?php
 include_once('../models/DashboardPanel.php');
-
 $roleViews = [
     Role::User => [
         new DashboardPanel("/attendance", "Record Attendance", "Participants", "clock-o"),
@@ -27,6 +26,7 @@ $roleViews = [
         new DashboardPanel("/manage-users", "User Management", "Employees", "users"),
         new DashboardPanel("/agency-requests", "Agency Requests", "Participants", "search"),
     ]
+	
 ];
 
 include('header.php');
@@ -35,20 +35,24 @@ include('header.php');
 
     <div id="dashboard-wrapper" class="d-flex flex-row justify-content-center flex-wrap">
         <?php
-        if ($_SESSION['role'] != Role::NewUser) {
-            /* @var $panel DashboardPanel */
-            foreach ($roleViews[$_SESSION['role']] as $panel) {
-                $panel->createPanel();
+            // Only display the dashboard once a session has begun
+            if (session_status() !== PHP_SESSION_NONE){
+                if ($_SESSION['role'] != Role::NewUser  ) {
+                    /* @var $panel DashboardPanel */
+                    foreach ($roleViews[$_SESSION['role']] as $panel) {
+                    $panel->createPanel();
+                    }
+                }else {
+                    ?>
+                    <div class="jumbotron align-self-center text-center" style="max-width: 700px; margin: 0 auto; width: 100%">
+                        <h1 class="display-3" style="color: #5C629C"><i class="fa fa-child"></i></h1>
+                        <h1 class="display-3">Welcome!</h1>
+                        <p class="lead">You currently have no role assigned, please see your supervisor.</p>
+                    </div>
+                    <?php
+                }   
+            }else{
             }
-        } else {
-            ?>
-            <div class="jumbotron align-self-center text-center" style="max-width: 700px; margin: 0 auto; width: 100%">
-                <h1 class="display-3" style="color: #5C629C"><i class="fa fa-child"></i></h1>
-                <h1 class="display-3">Welcome!</h1>
-                <p class="lead">You currently have no role assigned, please see your supervisor.</p>
-            </div>
-            <?php
-        }
         ?>
     </div>
 

--- a/views/logout.php
+++ b/views/logout.php
@@ -1,7 +1,43 @@
 <?php
 
 require_once('../config.php');
+global $params;
 
+/**
+ * Looks to see if there are any cookies set during the user'scandir
+ * session that may persist into a new session and unsets them.
+ *
+ */
+function unsetCookies(){
+    if (isset($_SERVER['HTTP_COOKIE'])) {
+        $cookies = explode(';', $_SERVER['HTTP_COOKIE']);
+        foreach($cookies as $cookie) {
+            $parts = explode('=', $cookie);
+            $name = trim($parts[0]);
+            setcookie($name, '', time()-1000);
+            setcookie($name, '', time()-1000, '/');
+        }
+    }  
+    
+}
+
+/**
+ * Just in case the header meta tags do not force the browser to clear it's cache
+ * for this site, the resetCache() fucntion will use headers to alert the browser
+ * to an expired cache, thus forcing a clear.
+ *
+ */
+function resetCache(){  
+    header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+    header('Cache-Control: no-store, no-cache, must-revalidate');
+    header('Cache-Control: post-check=0, pre-check=0', FALSE);
+    header('Pragma: no-cache');
+ 
+}
+// Unset all cookies and reset the cache before the destroying of the session
+unsetCookies();
+resetCache();
 session_destroy();
 
 header("Location: " . BASEURL . "/login");
+      


### PR DESCRIPTION
Fixes #96, #11 
- Tested across Chrome, Firefox and IE (latest of all versions)
- Clears cache on logout to prevent deployment issues
- Added timeout function to force logout after 1 hour
